### PR TITLE
Fix problem with bpe init

### DIFF
--- a/src/bpe_proc.erl
+++ b/src/bpe_proc.erl
@@ -81,7 +81,7 @@ init(Process) ->
          {error,_} -> Process end,
     Till = bpe:till(calendar:local_time(), kvs:config(bpe,ttl,24*60*60)),
     bpe:cache({process,Proc#process.id},self(),Till),
-    [ bpe:reg({messageEvent,element(1,EventRec),Proc#process.id}) || EventRec <- bpe:events(Proc) ],
+%    [ bpe:reg({messageEvent,element(1,EventRec),Proc#process.id}) || EventRec <- bpe:events(Proc) ],
     {ok, Proc#process{timer=erlang:send_after(rand:uniform(10000),self(),{timer,ping})}}.
 
 handle_cast(Msg, State) ->


### PR DESCRIPTION
I commented this line https://github.com/synrc/bpe/blob/v4.5/src/bpe_proc.erl#L84  because 
>  [ bpe:reg({messageEvent,element(1,EventRec),Proc#process.id}) || EventRec <- bpe:events(Proc) ].

=INFO REPORT==== 18-Jun-2019::23:29:01 ===
Terminating syn_registry with reason: {aborted,
                                       {no_exists,
                                        [syn_registry_table,
                                         <<131,104,3,100,0,12,109,101,115,
                                           115,97,103,101,69,118,101,110,
                                           116,100,0,13,98,111,117,110,100,
                                           97,114,121,69,118,101,110,116,97,
                                           1>>]}}** exception exit: {{aborted,{no_exists,[syn_registry_table,
                                         <<131,104,3,100,0,12,109,101,115,115,97,103,101,69,118,
                                           101,110,116,100,0,13,98,...>>]}},
                    {gen_server,call,
                                [{syn_registry,'mq@127.0.0.1'},
                                 {register_on_node,<<131,104,3,100,0,12,109,101,115,115,97,
                                                     103,101,69,118,101,110,116,100,0,...>>,
                                                   <0.75.0>,undefined}]}}
     in function  gen_server:call/2 (gen_server.erl, line 206)
     in call from bpe:reg/2 (/home/igor/IdeaProjects/dev/deps/bpe/src/bpe.erl, line 116)....

  

