### PR TITLE
Refactor2

### DIFF
--- a/include/bpe.hrl
+++ b/include/bpe.hrl
@@ -38,7 +38,7 @@
 -record(serviceTask,  { ?TASK }).
 -record(receiveTask,  { ?TASK, reader=[] :: #reader{} }).
 -record(sendTask,     { ?TASK, writer=[] :: #writer{} }).
--record(gateway,      { ?TASK, type= parallel :: gate(), filler=[] :: [] }).
+-record(gateway,      { ?TASK, type= parallel :: gate() }).
 -record(messageEvent, { ?EVENT }).
 -record(boundaryEvent,{ ?EVENT, ?CYCLIC }).
 -record(timeoutEvent, { ?EVENT, ?CYCLIC }).

--- a/include/bpe.hrl
+++ b/include/bpe.hrl
@@ -43,7 +43,7 @@
 -record(boundaryEvent,{ ?EVENT, ?CYCLIC }).
 -record(timeoutEvent, { ?EVENT, ?CYCLIC }).
 
--type tasks()  :: #task{} | #serviceTask{} | #userTask{} | #receiveTask{} | #beginEvent{} | #endEvent{}.
+-type tasks()  :: #task{} | #serviceTask{} | #userTask{} | #receiveTask{} | #sendTask{} | #beginEvent{} | #endEvent{}.
 -type events() :: #messageEvent{} | #boundaryEvent{} | #timeoutEvent{}.
 -type procId() :: [] | integer() | {atom(),any()}.
 -type gate()   :: exclusive | parallel | inclusive | complex | event.

--- a/src/bpe.erl
+++ b/src/bpe.erl
@@ -177,38 +177,35 @@ processFlow(#process{}=Proc) ->
 
 processSched(#sched{id=ScedId, pointer=Pointer, state=[]},Proc) -> {stop,normal,'Final',Proc};
 processSched(#sched{id=ScedId, pointer=Pointer, state=Threads},Proc) ->
-    X = lists:nth(Pointer, Threads),
     Flow = lists:keyfind(lists:nth(Pointer, Threads), #sequenceFlow.name, Proc#process.flows),
-    Vertex = lists:keyfind(Flow#sequenceFlow.target, #gateway.name, tasks(Proc)),
-    Required = element(#gateway.in, Vertex) -- [Flow],
-    Check = check_required2(ScedId, map_required_fun(Vertex),Required),
-    Inserted = case Check of true -> element(#gateway.out, Vertex); false -> [] end,
+    Task = lists:keyfind(Flow#sequenceFlow.target, #task.name, tasks(Proc)),
+    Inserted = get_inserted(Task, Flow, ScedId),
     NewThreads = lists:sublist(Threads, Pointer-1) ++ Inserted ++ lists:nthtail(Pointer, Threads),
     NewPointer = if Pointer == length(Threads) -> 1; true -> Pointer + length(Inserted) end,
     add_sched(Proc, NewPointer, NewThreads),
     #sequenceFlow{name=Next, source=Src,target=Dst} = Flow,
-    Source = step(Proc,Src),
-    Target = step(Proc,Dst),
-    Resp   = {Status,{Reason,_Reply},State}
-           = bpe_task:task_action(element(#task.module, Vertex),Src,Dst,Proc),
+    Resp = {Status,{Reason,_Reply},State}
+         = bpe_task:task_action(element(#task.module, Task),Src,Dst,Proc),
     add_trace(State,[],calendar:local_time(),Flow),
     bpe_proc:debug(State,Next,Src,Dst,Status,Reason),
     Resp.
 
-%TODO: get_Inserted(Vertex,Flow) -> Inserted
+get_inserted(#gateway{type=Type, in=In, out=Out},Flow,ScedId) when Type == inclusive;
+                                                                   Type == parallel ->
+    case check_all_flows(In -- [Flow], ScedId) of true -> Out; false -> [] end;
+get_inserted(#gateway{type=exclusive, out=Out},_,_) -> first_matched_flow(Out);
+get_inserted(T,_,_) -> element(#task.out, T).
 
-map_required_fun(#gateway{type=parallel})->
-    fun(Required, Flow) -> Required -- [Flow] end;
-map_required_fun(#gateway{type=inclusive})-> %%all
-    fun(Required, Flow) -> Required -- [Flow] end;
-map_required_fun(#gateway{type=exclusive}) -> %%any
-    fun(Required, Flow) -> case lists:member(Flow, Required) of true->[];false->Required end end;
-map_required_fun(_) -> fun(_,_) -> [] end.
+check_all_flows([],_) -> true;
+check_all_flows(_ ,#step{id = -1}) -> false;
+check_all_flows(Needed,ScedId) -> check_all_flows(Needed--[flow(sched(ScedId))],prev_step(ScedId)).
 
-check_required2(_,_,[]) -> true;
-check_required2(#step{id=-1},_,_) -> false;
-check_required2(#step{id=Id}=SchedId,MapFun,Required) ->
-    NewRequired = MapFun(Required, flow(sched(SchedId))),
-    check_required2(SchedId#step{id=Id-1}, MapFun, NewRequired).
+prev_step(Step=#step{id=Id}) -> Step#step{id=Id-1}.
+
+first_matched_flow([]) -> [];
+first_matched_flow([H | Flows]) -> 
+    case check_flow_condition(H) of true -> [H]; false -> first_matched_flow(Flows) end.
+
+check_flow_condition(_Flow) -> true. %%TODO: implement check of Flow#sequenceFlow.condition
 
 flow(#sched{state=Flows, pointer=N}) -> lists:nth(N, Flows).


### PR DESCRIPTION
For now we could skip all unsupported  BPMN entities and treat exclusive gateway as 'select first' rather than 'select first matched'. Later we should add support for actual conditions in sequenceFlow.